### PR TITLE
eltype updates for chain(), count()

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -21,14 +21,14 @@ export
 
 # Infinite counting
 
-immutable Count{S<:Number,T<:Number}
+immutable Count{S<:Number}
     start::S
-    step::T
+    step::S
 end
 
-eltype{S,T}(it::Count{S,T}) = promote_type(S,T)
+eltype{S}(it::Count{S}) = S
 
-count(start::Number, step::Number) = Count(start, step)
+count(start::Number, step::Number) = Count(promote(start, step)...)
 count(start::Number)               = Count(start, one(start))
 count()                            = Count(0, 1)
 
@@ -160,7 +160,13 @@ immutable Chain
     end
 end
 
-eltype(it::Chain) = promote_type([eltype(xs) for xs in it.xss]...)
+function eltype(it::Chain)
+    try
+        typejoin([eltype(xs) for xs in it.xss]...)
+    catch
+        Any
+    end
+end
 
 chain(xss...) = Chain(xss...)
 


### PR DESCRIPTION
In response to @JeffBezanson's comments here: https://github.com/JuliaLang/Iterators.jl/pull/11

_Edit:_ Updated the pull request to the following, which I think makes the most sense:
- `count()`: produce a consistent element type
- `chain()`: instead of `promote_type`, find common supertype of iterators

``` julia
julia> eltype(count(1, 2.0))
Float64

julia> collect(take(count(1, 2.0), 4))
4-element Array{Float64,1}:
 1.0
 3.0
 5.0
 7.0

julia> eltype(chain(1:2:5, 1.0:.1:1.3))
Real

julia> collect(chain(1:2:5, 1.0:.1:1.3))
7-element Array{Real,1}:
 1  
 3  
 5  
 1.0
 1.1
 1.2
 1.3
```
