### PR TITLE
Change product iteration order

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -237,11 +237,11 @@ function next(it::Product, state)
     ans = tuple(vs...)
 
     n = length(it.xss)
-    for i in 1:n
+    for i in n:-1:1
         if !done(it.xss[i], js[i])
             vs[i], js[i] = next(it.xss[i], js[i])
             break
-        elseif i == n
+        elseif i == 1
             vs = nothing
             break
         end
@@ -475,7 +475,7 @@ end
 
 function next(it::Subsets, state)
     ss = Array(eltype(it.xs), 0)
-    for i = 1:length(it.xs)
+    for i in 1:length(it.xs)
         if state[i]
             push!(ss, it.xs[i])
         end

--- a/test/test.jl
+++ b/test/test.jl
@@ -73,7 +73,7 @@ end
 
 x1 = 1:2:10
 x2 = 1:5
-@test collect(product(x1, x2)) == vec([(y1, y2) for y1 in x1, y2 in x2])
+@test collect(product(x1, x2)) == vec([(y1, y2) for y2 in x2, y1 in x1])
 
 # distinct
 # --------


### PR DESCRIPTION
Trivial, but seems more consistent to me. Changes `product(1:2, 1:2)` from
`[(1,1), (2,1), (1, 2), (2, 2)]` to
`[(1,1), (1,2), (2, 1), (2, 2)]`, which is consistent with `permutations` (and sorting or cross joining DataFrames).
