### PR TITLE
add everynth (iterate through every n'th element of a collection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Common functional iterator patterns.
     i => 2
     i => 3
     i => 4
-    i => 4
+    i => 5
     ```
 
 - **drop**(xs, n)
@@ -59,6 +59,22 @@ Common functional iterator patterns.
     i => 8
     i => 9
     i => 10
+    ```
+
+- **everynth**(xs, n)
+    
+    Iterate through every n'th element of `xs`
+
+    Example:
+    ```julia
+    collect(everynth(5:15,3))
+    ```
+
+    ```
+    3-element Array{Int32,1}:
+      7
+     10
+     13
     ```
 
 - **cycle**(xs)

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -16,7 +16,8 @@ export
     groupby,
     imap,
     subsets,
-    iterate
+    iterate,
+    everynth
 
 
 # Infinite counting
@@ -510,6 +511,45 @@ iterate(f, seed) = Iterate(f, seed)
 start(it::Iterate) = it.seed
 next(it::Iterate, state) = (state, it.f(state))
 done(it::Iterate, state) = (state==None)
+
+# everynth(xs,n): take every n'th element from xs
+
+immutable EveryNth{I}
+    xs::I
+    interval::Unsigned
+end
+
+type EveryNthState
+    xs_state
+    next_x
+end
+
+function everynth(xs, interval::Integer)
+    if interval<=0
+        throw(ArgumentError(string("expected interval to be 1 or more, ",
+                                   "got $interval")))
+    end
+    EveryNth(xs, convert(Unsigned, interval))
+end
+eltype(en::EveryNth) = eltype(en.xs)
+
+start(en::EveryNth) = EveryNthState(start(en.xs), nothing)
+
+function done(en::EveryNth, state::EveryNthState)
+    xs_state = state.xs_state
+    x = nothing
+    for i in 1:en.interval
+        if done(en.xs, xs_state)
+            return true
+        end
+        x, xs_state = next(en.xs, xs_state)
+    end
+    state.xs_state = xs_state
+    state.next_x = x
+    return false
+end
+
+next(::EveryNth, state::EveryNthState) = (state.next_x, state)
 
 end # module Iterators
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -180,4 +180,10 @@ test_groupby(
       {Symbol[], Symbol[:a], Symbol[:b], Symbol[:a, :b], Symbol[:c],
        Symbol[:a, :c], Symbol[:b, :c], Symbol[:a, :b, :c]}
 
+# every n'th element
+@test collect(everynth([], 10)) == []
+@test_throws ArgumentError everynth([], 0)
+@test collect(everynth(10:20, 3)) == [12,15,18]
+@test collect(everynth(10:20, 1)) == [10:20]
+
 


### PR DESCRIPTION
I needed this for a gibbs sampler and thought it might be generally useful: take every n'th element from a collection. e.g. collect(everynth(1:10, 3)) == [3,6,9]
