### PR TITLE
Remove length(::Take)

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -45,7 +45,6 @@ immutable Take{I}
 end
 
 eltype(it::Take) = eltype(it.xs)
-length(it::Take) = it.n
 
 take(xs, n::Int) = Take(xs, n)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,12 @@ end
 # take
 # ----
 
+t = take(0:2:8, 10)
+
+@test length(collect(t)) == 5
+
 i = 0
-for j = take(0:2:8, 10)
+for j = t
 	@test j == i*2
 	i += 1
 end


### PR DESCRIPTION
I just got bit by #25, which recommends two versions of Take -- one with a length (that throws if the iterable is too small) and one like this -- I figure that most people would expect the default (if there was a second version) to match Haskell and Clojure.
