### PR TITLE
RFC: Parametrize iterators based on applicable(length, it.xs); fixes #25

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -52,7 +52,6 @@ immutable Take{L,I}
 end
 
 eltype(it::Take) = eltype(it.xs)
-length(it::Take{false}) = it.n
 length(it::Take{true}) = min(it.n, length(xs))
 
 take(xs, n::Int) = Take{haslength(xs),typeof(xs)}(xs, n)


### PR DESCRIPTION
Some iterators wrap other iterators, and the wrapped iterable may or may not have a defined length.  This PR parametrizes the relevant iterator types based on whether or not `length` is defined for the wrapped iterable, and defines `length` for the iterator only when the wrapped array also has a length.

This is most useful for `collect(itr)`, which preallocates an output array if `length` is defined, or grows the output array otherwise.

Cc: @garborg, @ivarne 

Ref: https://github.com/JuliaLang/julia/issues/7429, #25, #27 
