### PR TITLE
Make order of arguments for groupby consistent with other iterators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,13 +224,13 @@ Install this package with `Pkg.add("Iterators")`
     i = (7,8,9)
     ```
 
-- **groupby**(xs, f)
+- **groupby**(f, xs)
 
     Group consecutive values that share the same result of applying `f`.
 
     Example:
     ```julia
-    for i in groupby(["face", "foo", "bar", "book", "baz", "zzz"], x -> x[1])
+    for i in groupby(x -> x[1], ["face", "foo", "bar", "book", "baz", "zzz"])
         @show i
     end
     ```

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -435,15 +435,20 @@ done(it::Partition, state) = done(it.xs, state[1])
 #       ["bar", "book", "baz"]
 #       ["zzz"]
 immutable GroupBy{I}
-    xs::I
     keyfunc::Function
+    xs::I
 end
 
 eltype{I}(it::GroupBy{I}) = I
 eltype{I<:Ranges}(it::GroupBy{I}) = Array{eltype(it.xs),}
 
-function groupby(xs, keyfunc)
-    GroupBy(xs, keyfunc)
+function groupby(xs, keyfunc::Function)
+    Base.warn_once("groupby(xs, keyfunc) should be groupby(keyfunc, xs)")
+    groupby(keyfunc, xs)
+end
+
+function groupby(keyfunc, xs)
+    GroupBy(keyfunc, xs)
 end
 
 function start(it::GroupBy)

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -58,16 +58,16 @@ abstract GroupBy
 type GroupBy1 <: GroupBy end
 type GroupBy2 <: GroupBy end
 
-collect(::GroupBy, v, f) = Base.collect(groupby(v, f))
+collect(::GroupBy, f, v) = Base.collect(groupby(f, v))
 
 function Base.run{Itr<:GroupBy}(p::Collect{Itr}, n::Int, state)
-    v, f = state
+    f, v = state
     op = Itr()
-    collect(op, v, f)
+    collect(op, f, v)
 end
 
-Base.start(::Collect{GroupBy1}, n::Int) = (["abc"[[rand(1:3), rand(1:3)]] for i = 1:n], x->x[1])
-Base.start(::Collect{GroupBy2}, n::Int) = (1:n, x->div(x,2))
+Base.start(::Collect{GroupBy1}, n::Int) = (x->x[1], ["abc"[[rand(1:3), rand(1:3)]] for i = 1:n])
+Base.start(::Collect{GroupBy2}, n::Int) = (iseven, [1:n])
 
 ############
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,7 +147,7 @@ test_imap(
 # -------
 
 function test_groupby(input, expected)
-  result = collect(groupby(input, x -> x[1]))
+  result = collect(groupby(x -> x[1], input))
   @test result == expected
 end
 


### PR DESCRIPTION
This switches the order of the function and collection arguments in `groupby` so that it is consistent with the  `imap` and `iterate` iterators and higher order functions in Base such as `map`. A warning is issued if `groupby` is called with arguments in the old order. 

Also, the `GroupBy2` benchmark was not being run, and I assume that was omitted by mistake. `GroupBy2` is now run.