### PR TITLE
Update groupby to allow grouping Ranges

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -419,6 +419,7 @@ immutable GroupBy{I}
 end
 
 eltype{I}(it::GroupBy{I}) = I
+eltype{I<:Ranges}(it::GroupBy{I}) = Array{eltype(it.xs),}
 
 function groupby(xs, keyfunc)
     GroupBy(xs, keyfunc)

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -67,7 +67,7 @@ function Base.run{Itr<:GroupBy}(p::Collect{Itr}, n::Int, state)
 end
 
 Base.start(::Collect{GroupBy1}, n::Int) = (["abc"[[rand(1:3), rand(1:3)]] for i = 1:n], x->x[1])
-Base.start(::Collect{GroupBy2}, n::Int) = ([1:n], iseven)
+Base.start(::Collect{GroupBy2}, n::Int) = (1:n, x->div(x,2))
 
 ############
 


### PR DESCRIPTION
Not really that useful, but it makes the original perf test actually work.
