### PR TITLE
Added some macro iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,6 @@ Install this package with `Pkg.add("Iterators")`
     i => 9
     ```
 
-
 - **subsets**(xs)
 
     Iterate over every subset of a collection `xs`.
@@ -277,7 +276,39 @@ Install this package with `Pkg.add("Iterators")`
     i => 16
     ```
 
+## The `@itr` macro for automatic inlining in `for` loops
 
-## Related projects
+Using functional iterators is powerful and concise, but may incur in some
+overhead, and manually inlining the operations can typically improve
+performance in critical parts of the code. The `@itr` macro is provided to do
+that automatically in some cases. Its usage is trivial: for example, given this code:
+```
+for (x,y) in zip(a,b)
+    @show x,y
+end
+```
+the automatically inlined version can be obtained by simply doing:
+```
+@itr for (x,y) in zip(a,b)
+    @show x,y
+end
+```
+This typically results in faster code, but its applicability has limitations:
 
-[MacroUtils](https://github.com/carlobaldassi/MacroUtils.jl#macroiterators) has more-performant macro versions of a few iterators.
+* it only works with `for` loops;
+* if multiple nested iterators are used, only the outermost is affected by the
+  transformation;
+* explicit expressions are required (i.e. when a `Tuple` is expected, an
+  explicit tuple must be provided, a tuple variable won't be accepted);
+* splicing is not supported;
+* multidimensional loops (i.e. expressions such as `for x in a, y in b`) are
+  not supported
+
+The `@itr` macro can be used with the following supported iterators:
+
+* zip
+* enumerate
+* take
+* takestrict
+* drop
+* chain

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,6 +175,7 @@ test_groupby(
 
 
 # subsets
+# -------
 
 @test collect(subsets({})) == {{}}
 
@@ -184,4 +185,171 @@ test_groupby(
       {Symbol[], Symbol[:a], Symbol[:b], Symbol[:a, :b], Symbol[:c],
        Symbol[:a, :c], Symbol[:b, :c], Symbol[:a, :b, :c]}
 
+## @itr
+## ====
 
+# @zip
+# ----
+
+macro test_zip(input...)
+    n = length(input)
+    x = Expr(:tuple, ntuple(i->gensym(), n)...)
+    v = Expr(:tuple, map(esc, input)...)
+    w = :(zip($(map(esc, input)...)))
+    quote
+	br = {}
+	for $x in zip($v...)
+	    push!(br, $x)
+	end
+	mr = {}
+	@itr for $x in $w
+	    push!(mr, $x)
+	end
+	@test br == mr
+    end
+end
+
+@test_zip [1,2,3] [:a, :b, :c] ['x', 'y', 'z']
+@test_zip [1,2,3] [:a, :b] ['w', 'x', 'y', 'z']
+@test_zip [1,2,3] [] ['w', 'x', 'y', 'z']
+
+# @enumerate
+# ----------
+
+macro test_enumerate(input)
+    i = gensym()
+    x = gensym()
+    v = esc(input)
+    quote
+	br = {}
+	for ($i,$x) in enumerate($v)
+	    push!(br, ($i,$x))
+	end
+	mr = {}
+	@itr for ($i,$x) in enumerate($v)
+	    push!(mr, ($i,$x))
+	end
+	@test br == mr
+    end
+end
+
+@test_enumerate [:a, :b, :c]
+@test_enumerate []
+
+# @take
+# -----
+
+macro test_take(input, n)
+    x = gensym()
+    v = esc(input)
+    quote
+	br = {}
+	for $x in take($v, $n)
+	    push!(br, $x)
+	end
+	mr = {}
+	@itr for $x in take($v, $n)
+	    push!(mr, $x)
+	end
+	@test br == mr
+    end
+end
+
+@test_take [:a, :b, :c] 2
+@test_take [:a, :b, :c] 5
+@test_take [:a, :b, :c] 0
+@test_take [] 2
+@test_take {} 0
+@test_take [(:a,1), (:b,2), (:c,3)] 2
+
+# @takestrict
+# -----
+
+macro test_takestrict(input, n)
+    x = gensym()
+    v = esc(input)
+    quote
+	br = {}
+	bfailed = false
+	try
+	    for $x in takestrict($v, $n)
+		push!(br, $x)
+	    end
+	catch
+	    bfailed = true
+	end
+
+	mr = {}
+	mfailed = false
+	try
+	    @itr for $x in takestrict($v, $n)
+		push!(mr, $x)
+	    end
+	catch
+	    mfailed = true
+	end
+	@test br == mr
+	@test bfailed == mfailed
+    end
+end
+
+@test_takestrict [:a, :b, :c] 2
+@test_takestrict [:a, :b, :c] 3
+@test_takestrict [:a, :b, :c] 5
+@test_takestrict [:a, :b, :c] 0
+@test_takestrict [] 2
+@test_takestrict {} 0
+@test_takestrict [(:a,1), (:b,2), (:c,3)] 2
+@test_takestrict [(:a,1), (:b,2), (:c,3)] 3
+@test_takestrict [(:a,1), (:b,2), (:c,3)] 4
+
+# @drop
+# -----
+
+macro test_drop(input, n)
+    x = gensym()
+    v = esc(input)
+    quote
+	br = {}
+	for $x in drop($v, $n)
+	    push!(br, $x)
+	end
+	mr = {}
+	@itr for $x in drop($v, $n)
+	    push!(mr, $x)
+	end
+	@test br == mr
+    end
+end
+
+@test_drop [:a, :b, :c] 2
+@test_drop [:a, :b, :c] 5
+@test_drop [:a, :b, :c] 0
+@test_drop [] 2
+@test_drop {} 0
+@test_drop [(:a,1), (:b,2), (:c,3)] 2
+
+# @chain
+# -----
+
+macro test_chain(input...)
+    x = gensym()
+    v = Expr(:tuple, map(esc, input)...)
+    w = :(chain($(map(esc, input)...)))
+    quote
+	br = {}
+	for $x in chain($v...)
+	    push!(br, $x)
+	end
+	mr = {}
+	@itr for $x in $w
+	    push!(mr, $x)
+	end
+	@test br == mr
+    end
+end
+
+@test_chain [1,2,3] [:a, :b, :c] ['x', 'y', 'z']
+@test_chain [1,2,3] [:a, :b] ['w', 'x', 'y', 'z']
+@test_chain [1,2,3] [] ['w', 'x', 'y', 'z']
+@test_chain [1,2,3] 4 [('w',3), ('x',2), ('y',1), ('z',0)]


### PR DESCRIPTION
As per the discussion in 1bbeeeee39a5936ee4c29fd704390befd96be653.

This adds macro versions of
- zip
- enumerate
- take/takestrict
- drop
- chain

which work on for loops. They all follow the same general syntax: whenever one would write

```
for VARS in ITERATOR(ARGUMENTS)
  BODY
end
```

the corresponding macro version is:

```
@ITERATOR for VARS in ARGUMENTS
  BODY
end
```
