### PR TITLE
RFC: Update eltype to operate on types

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -1,5 +1,6 @@
 module Iterators
 using Base
+import Compat
 
 import Base: start, next, done, count, take, eltype, length
 
@@ -28,7 +29,7 @@ immutable Count{S<:Number}
     step::S
 end
 
-eltype{S}(it::Count{S}) = S
+eltype{S}(::Type{Count{S}}) = S
 
 count(start::Number, step::Number) = Count(promote(start, step)...)
 count(start::Number)               = Count(start, one(start))
@@ -46,7 +47,7 @@ immutable Take{I}
     n::Int
 end
 
-eltype(it::Take) = eltype(it.xs)
+eltype{I}(::Type{Take{I}}) = eltype(I)
 
 take(xs, n::Int) = Take(xs, n)
 
@@ -72,7 +73,7 @@ immutable TakeStrict{I}
     n::Int
 end
 
-eltype(it::TakeStrict) = eltype(it.xs)
+eltype{I}(::Type{TakeStrict{I}}) = eltype(I)
 
 takestrict(xs, n::Int) = TakeStrict(xs, n)
 
@@ -107,7 +108,7 @@ immutable Drop{I}
     n::Int
 end
 
-eltype(it::Drop) = eltype(it.xs)
+eltype{I}(::Type{Drop{I}}) = eltype(I)
 
 drop(xs, n::Int) = Drop(xs, n)
 
@@ -133,7 +134,7 @@ immutable Cycle{I}
     xs::I
 end
 
-eltype(it::Cycle) = eltype(it.xs)
+eltype{I}(::Type{Cycle{I}}) = eltype(I)
 
 cycle(xs) = Cycle(xs)
 
@@ -160,7 +161,7 @@ immutable Repeat{O}
     n::Int
 end
 
-eltype{O}(it::Repeat{O}) = O
+eltype{O}(::Type{Repeat{O}}) = O
 length(it::Repeat) = it.n
 
 repeated(x, n) = Repeat(x, n)
@@ -174,7 +175,7 @@ immutable RepeatForever{O}
     x::O
 end
 
-eltype{O}(r::RepeatForever{O}) = O
+eltype{O}(::Type{RepeatForever{O}}) = O
 
 repeated(x) = RepeatForever(x)
 
@@ -324,7 +325,7 @@ immutable Distinct{I}
     Distinct(xs) = new(xs, Dict{Any, Int}())
 end
 
-eltype(it::Distinct) = eltype(it.xs)
+eltype{I}(::Type{Distinct{I}}) = eltype(I)
 
 distinct{I}(xs::I) = Distinct{I}(xs)
 
@@ -359,13 +360,15 @@ done(it::Distinct, state) = done(it.xs, state[1])
 #   partition(count(1), 2, 1) = (1,2), (2,3), (3,4) ...
 #   partition(count(1), 2, 3) = (1,2), (4,5), (7,8) ...
 
-immutable Partition{I}
+immutable Partition{I,N}
     xs::I
     n::Int
     step::Int
 end
 
-eltype(it::Partition) = tuple(fill(eltype(it.xs),it.n)...)
+Partition(xs,n,step) = Partition{typeof(xs),n}(xs,n,step)
+
+eltype{I,N}(::Type{Partition{I,N}}) = tuple(fill(eltype(I),N)...)
 
 function partition(xs, n::Int)
     Partition(xs, n, n)
@@ -439,8 +442,8 @@ immutable GroupBy{I}
     keyfunc::Function
 end
 
-eltype{I}(it::GroupBy{I}) = I
-eltype{I<:Ranges}(it::GroupBy{I}) = Array{eltype(it.xs),}
+eltype{I}(::Type{GroupBy{I}}) = I
+eltype{I<:Ranges}(::Type{GroupBy{I}}) = Array{eltype(I),1}
 
 function groupby(xs, keyfunc)
     GroupBy(xs, keyfunc)
@@ -515,11 +518,11 @@ end
 
 # Iterate over all subsets of a collection
 
-immutable Subsets
-    xs
+immutable Subsets{I}
+    xs::I
 end
 
-eltype(it::Subsets) = Array{eltype(it.xs),1}
+eltype{I}(::Type{Subsets{I}}) = Array{eltype(I),1}
 length(it::Subsets) = 1 << length(it.xs)
 
 function subsets(xs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,11 @@ using Iterators, Base.Test
 # -----
 
 i = 0
-for j = count(0, 2)
+c0 = count(0,2)
+
+@test eltype(c0) == Int
+
+for j = c0
 	@test j == i*2
 	i += 1
 	i <= 10 || break
@@ -13,12 +17,13 @@ end
 # take
 # ----
 
-t = take(0:2:8, 10)
+t0 = take(0:2:8, 10)
 
-@test length(collect(t)) == 5
+@test length(collect(t0)) == 5
+@test eltype(t0) == Int
 
 i = 0
-for j = t
+for j = t0
 	@test j == i*2
 	i += 1
 end
@@ -35,7 +40,11 @@ end
 # ----
 
 i = 0
-for j = drop(0:2:10, 2)
+d0 = drop(0:2:10, 2)
+
+@test eltype(d0) == Int
+
+for j = d0
 	@test j == (i+2)*2
 	i += 1
 end
@@ -45,7 +54,11 @@ end
 # -----
 
 i = 0
-for j = cycle(0:3)
+c2 = cycle(0:3)
+
+@test eltype(c2) == Int
+
+for j = c2
 	@test j == i % 4
 	i += 1
 	i <= 10 || break
@@ -55,7 +68,11 @@ end
 # --------
 
 i = 0
-for j = repeated(1, 10)
+r1 = repeated(1,10)
+
+@test eltype(r1) == Int
+
+for j = r1
 	@test j == 1
 	i += 1
 end
@@ -71,6 +88,7 @@ end
 # ----------
 
 i = 0
+
 for j = repeatedly(() -> 1, 10)
 	@test j == 1
 	i += 1
@@ -85,20 +103,28 @@ end
 # chain
 # -----
 
-@test collect(chain(1:2:5, 0.2:0.1:1.6)) == [1:2:5, 0.2:0.1:1.6]
+c3 = chain(1:2:5, 0.2:0.1:1.6)
+
+@test collect(c3) == [1:2:5; 0.2:0.1:1.6]
+@test eltype(c3) == typejoin(Int, Float64)
 
 # product
 # -------
 
 x1 = 1:2:10
 x2 = 1:5
-@test collect(product(x1, x2)) == vec([(y1, y2) for y1 in x1, y2 in x2])
+px = product(x1, x2)
+@test collect(px) == vec([(y1, y2) for y1 in x1, y2 in x2])
+@test eltype(px) == (Int,Int)
 
 # distinct
 # --------
 
 x = [5, 2, 2, 1, 2, 1, 1, 2, 4, 2]
-@test collect(distinct(x)) == unique(x)
+dx = distinct(x)
+
+@test collect(dx) == unique(x)
+@test eltype(dx) == Int
 
 # partition
 # ---------
@@ -107,39 +133,41 @@ x = [5, 2, 2, 1, 2, 1, 1, 2, 4, 2]
 @test collect(partition(take(count(1), 4), 2, 1)) == [(1,2), (2,3), (3,4)]
 @test collect(partition(take(count(1), 8), 2, 3)) == [(1,2), (4,5), (7,8)]
 
+@test eltype(partition(take(count(1), 6), 2)) == (Int, Int)
+
 # imap
 # ----
 
 function test_imap(expected, input...)
-  result = collect(imap(+, input...))
-  @test result == expected
+    result = collect(imap(+, input...))
+    @test result == expected
 end
 
 
 # Empty arrays
 test_imap(
-  Any[],
-  Union()[]
+    Any[],
+    Union()[]
 )
 
 # Simple operation
 test_imap(
-  Any[1,2,3],
-  [1,2,3]
+    Any[1,2,3],
+    [1,2,3]
 )
 
 # Multiple arguments
 test_imap(
-  Any[5,7,9],
-  [1,2,3],
-  [4,5,6]
+    Any[5,7,9],
+    [1,2,3],
+    [4,5,6]
 )
 
 # Different-length arguments
 test_imap(
-  Any[2,4,6],
-  [1,2,3],
-  count(1)
+    Any[2,4,6],
+    [1,2,3],
+    count(1)
 )
 
 
@@ -147,27 +175,28 @@ test_imap(
 # -------
 
 function test_groupby(input, expected)
-  result = collect(groupby(input, x -> x[1]))
-  @test result == expected
+    g = groupby(input, x -> x[1])
+    result = collect(groupby(input, x -> x[1]))
+    @test result == expected
 end
 
 
 # Empty arrays
 test_groupby(
-  Union()[],
-  Any[]
+    Union()[],
+    Any[]
 )
 
 # Singletons
 test_groupby(
-  ["xxx"],
-  Any[["xxx"]]
+    ["xxx"],
+    Any[["xxx"]]
 )
 
 # Typical operation
 test_groupby(
-  ["face", "foo", "bar", "book", "baz"],
-  Any[["face", "foo"], ["bar", "book", "baz"]]
+    ["face", "foo", "bar", "book", "baz"],
+    Any[["face", "foo"], ["bar", "book", "baz"]]
 )
 
 # Trailing singletons


### PR DESCRIPTION
* Based on https://github.com/JuliaLang/julia/commit/a2627adb
* Depends on https://github.com/JuliaLang/Compat.jl/pull/43
* As with the change in Base, eltype for Chains, Product is
  still based on instances, not Types
* Added type parameters to Partition, Subsets