### PR TITLE
WIP: Added 'order' keyword argument to cartesian product

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ Install this package with `Pkg.add("Iterators")`
     i = 'c'
     ```
 
-- **product**(xs...)
+- **product**(xs..., [order])
 
-    Iterate over all combinations in the cartesian product of the inputs.
+    Iterate over all combinations in the cartesian product of the inputs. The `order` keyword argument specifies whether the elements are traversed in lexicographic order (`false`) or anti-lexicographic order (`true`, the default value).
 
     Example:
     ```julia
@@ -169,6 +169,21 @@ Install this package with `Pkg.add("Iterators")`
     p = (3,1)
     p = (1,2)
     p = (2,2)
+    p = (3,2)
+    ```
+    while
+    ```julia
+    for p in product(1:3,1:2,order=false)
+        @show p
+    end
+    ```
+    yields
+    ```
+    p = (1,1)
+    p = (1,2)
+    p = (2,1)
+    p = (2,2)
+    p = (3,1)
     p = (3,2)
     ```
 

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -260,15 +260,20 @@ done(it::Chain, state) = state[1] > length(it.xss)
 
 immutable Product
     xss::Vector{Any}
-    function Product(xss...)
-        new(Any[xss...])
+    order::Bool
+    function Product(xss...;order=true)
+        if order
+            new(Any[xss...],order)
+        else
+            new(reverse(Any[xss...]),order)
+        end
     end
 end
 
 eltype(p::Product) = tuple(map(eltype, p.xss)...)
 length(p::Product) = prod(map(length, p.xss))
 
-product(xss...) = Product(xss...)
+product(xss...; order=true) = Product(xss..., order=order)
 
 function start(it::Product)
     n = length(it.xss)
@@ -291,7 +296,11 @@ end
 function next(it::Product, state)
     js = copy(state[1])
     vs = copy(state[2])
-    ans = tuple(vs...)
+    ans = if it.order 
+             tuple(vs...)
+          else
+             tuple(reverse(vs)...)
+          end 
 
     n = length(it.xss)
     for i in 1:n

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,8 @@ x1 = 1:2:10
 x2 = 1:5
 @test collect(product(x1, x2)) == vec([(y1, y2) for y1 in x1, y2 in x2])
 
+@test collect(product(x1, x2, order=false)) == vec([(y1, y2) for y2 in x2, y1 in x1])
+
 # distinct
 # --------
 


### PR DESCRIPTION
A simple fix to #37 

Currently it only handles anti-lexicographical (the default) and lexicographical ordering (the new addition).  The `order` keyword argument takes a boolean argument, not because I thought it was a great idea, but because I could not think of a better one.  I suppose an enum of the supported orderings would be the proper type for the `order` argument, but until enum support in Julia lands, I don't have a better idea.

The way the two orderings are handled could also be cleaner.  If we really think there is a need/demand for more orderings, should each ordering have a different type, selected via the `order` argument?

These issues aside, the code can be merged.

Comments welcome.
