### PR TITLE
Iterate over all subsets of a given size (with performance improvements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,23 @@ Install this package with `Pkg.add("Iterators")`
     i = [1,2,3]
     ```
 
+- **subsets**(xs, k)
+
+    Iterate over every subset of size `k` from a collection `xs`.
+
+    Example:
+    ```julia
+    for i in subsets([1,2,3],2)
+     @show i
+    end
+    ```
+
+    ```
+    i = [1,2]
+    i = [1,3]
+    i = [2,3]
+    ```
+
 - **iterate**(f, x)
 
     Iterate over succesive applications of `f`, as in `f(x), f(f(x)), f(f(f(x))), ...`.

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -561,6 +561,45 @@ function done(it::Subsets, state)
     state[end]
 end
 
+
+# Iterate over all subsets of a collection with a given size
+
+immutable Binomial{T}
+    xs::Array{T,1}
+    n::Int64
+    k::Int64
+end
+
+eltype(it::Binomial) = Array{eltype(it.xs),1}
+length(it::Binomial) = binomial(it.n,it.k)
+
+subsets(xs,k) = Binomial(xs,length(xs),k)
+
+start(it::Binomial) = (Int64[1:it.k],false)
+
+function next(it::Binomial,state::(Array{Int64,1},Bool))
+    idx = state[1]
+    set = it.xs[idx]
+    i = it.k
+    while(i>0)
+        if idx[i] < it.n - it.k + i
+            idx[i] += 1
+            idx[i+1:it.k] = [idx[i]+1:idx[i]+it.k-i]
+            break
+        else
+            i -= 1
+        end
+    end
+    if i==0
+        return set, (idx,true)
+    else
+        return set, (idx,false)
+    end
+end
+
+done(it::Binomial,state::(Array{Int64,1},Bool)) = state[2]
+
+
 # Unfolding (anamorphism)
 # Outputs the stream: seed, f(seed), f(f(seed)), ...
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,6 +200,20 @@ test_groupby(
       Any[Symbol[], Symbol[:a], Symbol[:b], Symbol[:a, :b], Symbol[:c],
           Symbol[:a, :c], Symbol[:b, :c], Symbol[:a, :b, :c]]
 
+
+# subsets of size k
+# -----------------
+
+@test collect(subsets(Any[],0)) == Any[Any[]]
+@test collect(subsets([:a, :b, :c],1)) == Any[Symbol[:a], Symbol[:b], Symbol[:c]]
+@test collect(subsets([:a, :b, :c],2)) == Any[Symbol[:a,:b], Symbol[:a,:c], Symbol[:b,:c]]
+@test collect(subsets([:a, :b, :c],3)) == Any[Symbol[:a,:b,:c]]
+@test length(collect(subsets([1:4],1))) == binomial(4,1)
+@test length(collect(subsets([1:4],2))) == binomial(4,2)
+@test length(collect(subsets([1:4],3))) == binomial(4,3)
+@test length(collect(subsets([1:4],4))) == binomial(4,4)
+
+
 ## @itr
 ## ====
 


### PR DESCRIPTION
There is currently an iterator ```subsets``` that iterates over all subsets of a collection, but it is often convenient to iterate only over *subsets of a given size*.

I implemented a simple and reasonably fast iterator to do that. It overloads the ```subsets``` function to accept an additional integer argument specifying the desired size of the subsets. 

Example:
```
julia> for s in subsets([1:4],2)
           @show s
       end
s => [1,2]
s => [1,3]
s => [1,4]
s => [2,3]
s => [2,4]
s => [3,4]
```

The iterator is also significantly faster than the current "all subsets" iterator when used to iterate over all sets. For example, here is the old iterator:

```
julia> @time for s in subsets([1:20]) pass end
elapsed time: 2.981504003 seconds (1111175376 bytes allocated, 10.86% gc time)
```

Here is the new iterator:
```
julia> @time for k in 0:20 for s in subsets([1:20],k) pass end end
elapsed time: 0.169338439 seconds (267043056 bytes allocated, 37.64% gc time)
```