### PR TITLE
Use Base types when available and fix tests on 0.4-dev

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,2 @@
+julia 0.3
+# Compat

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -1,9 +1,12 @@
 module Iterators
 using Base
+# Not needed now since it does not work
+# using Compat
 
 import Base: start, next, done, count, take, eltype, length
 
 export
+    countfrom,
     count,
     take,
     takestrict,
@@ -23,46 +26,60 @@ export
 
 # Infinite counting
 
-immutable Count{S<:Number}
-    start::S
-    step::S
+if VERSION >= v"0.4-dev"
+    import Base: Count
+    @deprecate count(start::Number, step::Number) countfrom(start, step)
+    @deprecate count(start::Number)               countfrom(start)
+    @deprecate count()                            countfrom(1)
+else
+    immutable Count{S<:Number}
+        start::S
+        step::S
+    end
+
+    eltype{S}(it::Count{S}) = S
+
+    countfrom(start::Number, step::Number) = Count(promote(start, step)...)
+    countfrom(start::Number)               = Count(start, one(start))
+    countfrom()                            = Count(1, 1)
+
+    start(it::Count) = it.start
+    next(it::Count, state) = (state, state + it.step)
+    done(it::Count, state) = false
+
+    # Deprecate on 0.3 as well?
+    count(start::Number, step::Number) = countfrom(start, step)
+    count(start::Number)               = countfrom(start)
+    count()                            = countfrom(1)
 end
-
-eltype{S}(it::Count{S}) = S
-
-count(start::Number, step::Number) = Count(promote(start, step)...)
-count(start::Number)               = Count(start, one(start))
-count()                            = Count(0, 1)
-
-start(it::Count) = it.start
-next(it::Count, state) = (state, state + it.step)
-done(it::Count, state) = false
-
 
 # Iterate through the first n elements
 
-immutable Take{I}
-    xs::I
-    n::Int
+if VERSION >= v"0.4-dev"
+    import Base: Take
+else
+    immutable Take{I}
+        xs::I
+        n::Int
+    end
+
+    eltype(it::Take) = eltype(it.xs)
+
+    take(xs, n::Int) = Take(xs, n)
+
+    start(it::Take) = (it.n, start(it.xs))
+
+    function next(it::Take, state)
+        n, xs_state = state
+        v, xs_state = next(it.xs, xs_state)
+        return v, (n - 1, xs_state)
+    end
+
+    function done(it::Take, state)
+        n, xs_state = state
+        return n <= 0 || done(it.xs, xs_state)
+    end
 end
-
-eltype(it::Take) = eltype(it.xs)
-
-take(xs, n::Int) = Take(xs, n)
-
-start(it::Take) = (it.n, start(it.xs))
-
-function next(it::Take, state)
-    n, xs_state = state
-    v, xs_state = next(it.xs, xs_state)
-    return v, (n - 1, xs_state)
-end
-
-function done(it::Take, state)
-    n, xs_state = state
-    return n <= 0 || done(it.xs, xs_state)
-end
-
 
 # Iterate through the first n elements, throwing an exception if
 # fewer than n items ar encountered.
@@ -99,88 +116,100 @@ function length(it::TakeStrict)
     return it.n
 end
 
-
 # Iterator through all but the first n elements
 
-immutable Drop{I}
-    xs::I
-    n::Int
-end
-
-eltype(it::Drop) = eltype(it.xs)
-
-drop(xs, n::Int) = Drop(xs, n)
-
-function start(it::Drop)
-    xs_state = start(it.xs)
-    for i in 1:it.n
-        if done(it.xs, xs_state)
-            break
-        end
-
-        _, xs_state = next(it.xs, xs_state)
+if VERSION >= v"0.4-dev"
+    import Base: Drop
+else
+    immutable Drop{I}
+        xs::I
+        n::Int
     end
-    xs_state
+
+    eltype(it::Drop) = eltype(it.xs)
+
+    drop(xs, n::Int) = Drop(xs, n)
+
+    function start(it::Drop)
+        xs_state = start(it.xs)
+        for i in 1:it.n
+            if done(it.xs, xs_state)
+                break
+            end
+
+            _, xs_state = next(it.xs, xs_state)
+        end
+        xs_state
+    end
+
+    next(it::Drop, state) = next(it.xs, state)
+    done(it::Drop, state) = done(it.xs, state)
 end
-
-next(it::Drop, state) = next(it.xs, state)
-done(it::Drop, state) = done(it.xs, state)
-
 
 # Cycle an iterator forever
 
-immutable Cycle{I}
-    xs::I
-end
-
-eltype(it::Cycle) = eltype(it.xs)
-
-cycle(xs) = Cycle(xs)
-
-function start(it::Cycle)
-    s = start(it.xs)
-    return s, done(it.xs, s)
-end
-
-function next(it::Cycle, state)
-    s, d = state
-    if done(it.xs, s)
-        s = start(it.xs)
+if VERSION >= v"0.4-dev"
+    using Base: Cycle
+else
+    immutable Cycle{I}
+        xs::I
     end
-    v, s = next(it.xs, s)
-    return v, (s, false)
-end
 
-done(it::Cycle, state) = state[2]
+    eltype(it::Cycle) = eltype(it.xs)
+
+    cycle(xs) = Cycle(xs)
+
+    function start(it::Cycle)
+        s = start(it.xs)
+        return s, done(it.xs, s)
+    end
+
+    function next(it::Cycle, state)
+        s, d = state
+        if done(it.xs, s)
+            s = start(it.xs)
+        end
+        v, s = next(it.xs, s)
+        return v, (s, false)
+    end
+
+    done(it::Cycle, state) = state[2]
+end
 
 # Repeat an object n (or infinitely many) times.
 
-immutable Repeat{O}
-    x::O
-    n::Int
+if VERSION >= v"0.4-dev"
+    import Base: Repeated
+    typealias RepeatForever{O} Repeated{O}
+    typealias Repeat{O} Take{Repeated{O}}
+else
+    immutable Repeat{O}
+        x::O
+        n::Int
+    end
+
+    eltype{O}(it::Repeat{O}) = O
+    length(it::Repeat) = it.n
+
+    repeated(x, n) = Repeat(x, n)
+
+    start(it::Repeat) = it.n
+    next(it::Repeat, state) = (it.x, state - 1)
+    done(it::Repeat, state) = state <= 0
+
+
+    immutable RepeatForever{O}
+        x::O
+    end
+
+    eltype{O}(r::RepeatForever{O}) = O
+
+    repeated(x) = RepeatForever(x)
+
+    start(it::RepeatForever) = nothing
+    next(it::RepeatForever, state) = (it.x, nothing)
+    done(it::RepeatForever, state) = false
 end
-
-eltype{O}(it::Repeat{O}) = O
-length(it::Repeat) = it.n
-
-repeated(x, n) = Repeat(x, n)
-
-start(it::Repeat) = it.n
-next(it::Repeat, state) = (it.x, state - 1)
-done(it::Repeat, state) = state <= 0
-
-
-immutable RepeatForever{O}
-    x::O
-end
-
-eltype{O}(r::RepeatForever{O}) = O
-
-repeated(x) = RepeatForever(x)
-
-start(it::RepeatForever) = nothing
-next(it::RepeatForever, state) = (it.x, nothing)
-done(it::RepeatForever, state) = false
 
 # Repeat a function application n (or infinitely many) times.
 
@@ -265,7 +294,13 @@ immutable Product
     end
 end
 
-eltype(p::Product) = tuple(map(eltype, p.xss)...)
+# Using @compat causes error JuliaLang/Compat.jl#81
+# eltype(p::Product) = @compat(Tuple{map(eltype, p.xss)...})
+if VERSION >= v"0.4-dev"
+    eltype(p::Product) = Tuple{map(eltype, p.xss)...}
+else
+    eltype(p::Product) = tuple(map(eltype, p.xss)...)
+end
 length(p::Product) = prod(map(length, p.xss))
 
 product(xss...) = Product(xss...)
@@ -365,7 +400,13 @@ immutable Partition{I}
     step::Int
 end
 
-eltype(it::Partition) = tuple(fill(eltype(it.xs),it.n)...)
+# Using @compat causes error JuliaLang/Compat.jl#81
+# eltype(it::Partition) = @compat(Tuple{fill(eltype(it.xs),it.n)...})
+if VERSION >= v"0.4-dev"
+    eltype(it::Partition) = Tuple{fill(eltype(it.xs),it.n)...}
+else
+    eltype(it::Partition) = tuple(fill(eltype(it.xs),it.n)...)
+end
 
 function partition(xs, n::Int)
     Partition(xs, n, n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Iterators, Base.Test
 # -----
 
 i = 0
-for j = count(0, 2)
+for j = countfrom(0, 2)
 	@test j == i*2
 	i += 1
 	i <= 10 || break
@@ -85,7 +85,7 @@ end
 # chain
 # -----
 
-@test collect(chain(1:2:5, 0.2:0.1:1.6)) == [1:2:5, 0.2:0.1:1.6]
+@test collect(chain(1:2:5, 0.2:0.1:1.6)) == [1:2:5; 0.2:0.1:1.6]
 
 # product
 # -------
@@ -103,9 +103,9 @@ x = [5, 2, 2, 1, 2, 1, 1, 2, 4, 2]
 # partition
 # ---------
 
-@test collect(partition(take(count(1), 6), 2)) == [(1,2), (3,4), (5,6)]
-@test collect(partition(take(count(1), 4), 2, 1)) == [(1,2), (2,3), (3,4)]
-@test collect(partition(take(count(1), 8), 2, 3)) == [(1,2), (4,5), (7,8)]
+@test collect(partition(take(countfrom(1), 6), 2)) == [(1,2), (3,4), (5,6)]
+@test collect(partition(take(countfrom(1), 4), 2, 1)) == [(1,2), (2,3), (3,4)]
+@test collect(partition(take(countfrom(1), 8), 2, 3)) == [(1,2), (4,5), (7,8)]
 
 # imap
 # ----
@@ -139,7 +139,7 @@ test_imap(
 test_imap(
   Any[2,4,6],
   [1,2,3],
-  count(1)
+  countfrom(1)
 )
 
 


### PR DESCRIPTION
1. Add `Compat.jl` dependency (for tuple types)
2. Use types (and functions) from `Base` on `0.4-dev`, including `Count`, `Take`, `Drop`, `Cycle`, `Repeat`, `RepeatForever`
3. Deprecate `count` on `0.4-dev` in favor of `countfrom` from `Base`
4. Fix some `eltype`s to return the correct tuple type
5. Fix deprecate warning of `[a, b, ...]` in `runtests.jl`
