### PR TITLE
Add a Concat Iterator

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -119,7 +119,6 @@ else
     end
 
     eltype(it::Cycle) = eltype(it.xs)
-
     cycle(xs) = Cycle(xs)
 
     function start(it::Cycle)
@@ -168,7 +167,48 @@ else
     done(it::RepeatForever, state) = false
 end
 
+# Given an iterator that produces iterators, concat the value obtained from them
 
+type Concat{T,state}
+    it::T
+    laststate::state
+    nextstate::state
+    Concat(it::T,firststate::state) = new(it)
+end
+Concat{T}(it::T) = Concat{T,Any}(it,((),nothing,0))
+
+function start{T,state}(it::Concat{T,state})
+    it_state = start(it.it)
+    if done(it.it, it_state)
+        return ((),it_state,start())
+    else
+        (current_it, it_state) = next(it.it, it_state)
+        child_state = start(current_it)
+        return (current_it, it_state, child_state)
+    end
+end
+
+function done(it::Concat,state)
+    it.laststate = state
+    current_it = state[1]
+    it_state = state[2]
+    child_state = state[3]
+    while done(current_it, child_state) && !done(it.it, it_state)
+        (current_it, it_state) = next(it.it, it_state)
+        child_state = start(current_it)
+    end
+    if done(current_it, child_state) && done(it.it, it_state)
+        return true
+    end
+    nextval, nextstate = next(current_it, child_state)
+    it.nextstate = (nextval, (current_it, it_state, nextstate))
+    return false
+end
+
+function next(it::Concat, state)
+    @assert it.laststate == state
+    it.nextstate
+end
 
 # Iterate through the first n elements, throwing an exception if
 # fewer than n items ar encountered.

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -15,7 +15,8 @@ export
     subsets,
     iterate,
     takenth,
-    @itr
+    @itr,
+    Concat
 
 
 # Some iterators have been moved into Base (and count has been renamed as well)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -391,3 +391,7 @@ end
 @test_chain [1,2,3] [:a, :b] ['w', 'x', 'y', 'z']
 @test_chain [1,2,3] Union()[] ['w', 'x', 'y', 'z']
 @test_chain [1,2,3] 4 [('w',3), ('x',2), ('y',1), ('z',0)]
+
+# Concat
+@test collect(Concat(([1,2,3],[4,5,6]))) == [1,2,3,4,5,6]
+@test collect(Concat(repeated(take(countfrom(),2),3))) == [1,2,1,2,1,2]


### PR DESCRIPTION
If you have an iterator that returns iterators, it is to concat them into a single iterators. Alternatively, this might be named `Flatten`.