### PR TITLE
Add precompile directive

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -1,3 +1,5 @@
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
+
 module Iterators
 
 using Compat


### PR DESCRIPTION
Passed `Pkg.test` on 0.4. Needed to resolve dependencies during precompilation.