### PR TITLE
RFC: Knowing iteratorsize via type parameters

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -247,13 +247,31 @@ done(it::RepeatCallForever, state) = false
 
 # Concatenate the output of n iterators
 
-immutable Chain
-    xss::Vector{Any}
-    function Chain(xss...)
-        new(Any[xss...])
-    end
+immutable Chain{U}
+    xss::Vector{U}
 end
-iteratorsize{T<:Chain}(::Type{T}) = SizeUnknown()
+
+
+function Chain(xss...)
+		U=Union{[typeof(xs) for xs in xss]...}
+        Chain{U}(U[xss...])
+end
+
+function iteratorsize{U}(::Type{Chain{U}})
+	for itype in U.types
+		if iteratorsize(itype)==IsInfinite()
+			return IsInfinite()
+		elseif iteratorsize(itype)==SizeUnknown()
+			return SizeUnknown()
+		end
+	end
+	return HasLength()
+end
+
+function length(it::Chain)
+	@assert(iteratorsize(it)==HasLength())
+	sum(map(length, it.xss))
+end
 
 function eltype(it::Chain)
     try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -393,3 +393,10 @@ end
 @test_chain [1,2,3] @compat(Union{})[] ['w', 'x', 'y', 'z']
 @test_chain [1,2,3] 4 [('w',3), ('x',2), ('y',1), ('z',0)]
 
+@testset "Chained iteratorsize inheritence" begin
+	@test Base.iteratorsize(chain(1:2:5, cycle(4))) == Base.IsInfinite()
+	@test Base.iteratorsize(chain(1:2:5, 0.2:0.1:1.6)) == Base.HasLength()
+	@test Base.iteratorsize(chain(1:2:5, distinct([1,1,10]))) == Base.SizeUnknown()
+
+	@test length(chain([1,2,3,4], eye(4))) == 20
+end

--- a/test/test.jl
+++ b/test/test.jl
@@ -68,6 +68,10 @@ end
 
 @test collect(chain(1:2:5, 0.2:0.1:1.6)) == [1:2:5, 0.2:0.1:1.6]
 
+@test Base.iteratorsize(chain(1:2:5, cycle(4))) == Base.IsInfinite()
+@test Base.iteratorsize(chain(1:2:5, 0.2:0.1:1.6)) == Base.HasLength()
+@test Base.iteratorsize(chain(1:2:5, distinct([1,1,10]))) == Base.SizeUnknown()
+
 # product
 # -------
 


### PR DESCRIPTION
I have been thinking about this since `iteratorsize` got pushed into Julia 0.5.
We should be able to know if the length of an combining iterator (eg Chain) is known,
based on what we know about the length of the iterators being combined.

This branch demonstrates how that could be done.
It works by what is arguably an abuse of `Union`
as `Union` is the type that has Varargs for type parameters (AFAIK).

Is this a good idea?
At least in concept?

I don't think this can be merged in its current state -- I think it would break 0.4.
Also the same technique could probably be used to give better iteratorsize in other iterators.