### PR TITLE
mergesorted - function to merge together 2 sorted iterators

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -9,6 +9,7 @@ export
     takestrict,
     repeatedly,
     chain,
+    mergesorted,
     product,
     distinct,
     partition,
@@ -159,7 +160,7 @@ else
 
     eltype{O}(it::Repeat{O}) = O
     length(it::Repeat) = it.n
-
+    
     repeated(x, n) = Repeat(x, n)
 
     start(it::Repeat) = it.n
@@ -893,5 +894,95 @@ macro chain(ex)
 
     Expr(:let, Expr(:block, cycleex...), states...)
 end
+
+
+type MergedIter
+    it1   # iterator 1
+    it2   # iterator 2
+    lt    # custom `<` operator to compare elements of 2 iterators    
+end
+
+MergeIter(it1, it2) = MergeIter(it1, it2, isless)
+
+type MergedState
+    hd1   # current head of 1st iterator
+    hd2   # current head of 2nd iterator
+    s1    # current state of 1st iterator
+    s2    # current state of 2nd iterator
+end
+
+
+function start(it::MergedIter)
+    s1 = start(it.it1)
+    s2 = start(it.it2)
+    # doing 1 step ahead and caching next element of each iter
+    hd1, s1 = safenext(it.it1, s1)
+    hd2, s2 = safenext(it.it2, s2)
+    return MergedState(hd1, hd2, s1, s2)
+end
+
+"""
+Like `next`, but may be called on iterator that is already done. In this case
+new item is `nothing` and new state is the same as previous. 
+"""
+function safenext(it, s)
+    if done(it, s)
+        return nothing, s
+    else
+        return next(it, s)
+    end
+end
+
+function next(it::MergedIter, s::MergedState)
+    lt = it.lt
+    if done(it, s) throw(ArgumentError("Iterator is done")) end
+    it1 = it.it1; it2 = it.it2; hd1 = s.hd1; hd2 = s.hd2; s1 = s.s1; s2 = s.s2
+    while hd1 == hd2 && hd2 != nothing
+        # move second iterator till heads are different or iterator is done
+        hd2, s2 = safenext(it2, s2)
+    end
+    if complete(it1, s1, hd1)
+        next_hd2, next_s2 = safenext(it2, s2)
+        return hd2, MergedState(hd1, next_hd2, s1, next_s2)
+    elseif complete(it2, s2, hd2)
+        next_hd1, next_s1 = safenext(it1, s1)
+        return hd1, MergedState(next_hd1, hd2, next_s1, s2)
+    elseif lt(hd1, hd2) # hd1 < hd2
+        next_hd1, next_s1 = safenext(it1, s1)
+        return hd1, MergedState(next_hd1, hd2, next_s1, s2)        
+    else
+        next_hd2, next_s2 = safenext(it2, s2)
+        return hd2, MergedState(hd1, next_hd2, s1, next_s2)
+    end
+end
+
+"""
+Check if iterator is done and head doesn't hold a cached value.
+"""
+function complete(it, s, hd)
+    return done(it, s) && hd == nothing
+end
+
+function done(it::MergedIter, s::MergedState)
+    return (done(it.it1, s.s1) && done(it.it2, s.s2) &&
+            s.hd1 == nothing && s.hd2 == nothing)
+end
+
+"""
+Merge 2 sorted iterators. Let `hd1` be a head of 1st iterator and `hd2` -
+a head of 2nd iterator. Then merged iterator works as follows: 
+
+ * if hd1 < hd2, hd1 is emitted
+ * if hd1 > hd2, hd2 is emitted
+ * if hd1 == hd2, hd1 is emitted and hd2 is discarded (so no duplicates
+                  are produced)
+ * if one of iterators is done, tail of another is taken
+
+Comparison is done using `lt` option that defaults to `isless` function. 
+"""
+function mergesorted(it1, it2; lt = isless)
+    return MergedIter(it1, it2, lt)
+end
+
 
 end # module Iterators

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -393,3 +393,24 @@ end
 @test_chain [1,2,3] @compat(Union{})[] ['w', 'x', 'y', 'z']
 @test_chain [1,2,3] 4 [('w',3), ('x',2), ('y',1), ('z',0)]
 
+# @mergesorted
+# ---
+
+macro test_mergesorted(it1, it2, expected)
+    x = gensym()
+    w = :(mergesorted($it1, $it2))
+    quote
+	actual = Any[]
+	for $x in $w
+	    push!(actual, $x)
+	end
+	@test actual == $expected
+    end
+end
+
+@test_mergesorted 1:10 5:15 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+@test_mergesorted 5:15 1:10 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+@test_mergesorted [:a, :c, :d, :f] [:b, :c, :d, :e] [:a, :b, :c, :d, :e, :f]
+@test_mergesorted [] ["aaa", "bbb", "ccc"] ["aaa", "bbb", "ccc"]
+@test_mergesorted ["aaa", "bbb", "ccc"] [] ["aaa", "bbb", "ccc"]
+@test_mergesorted [] [] []


### PR DESCRIPTION
Function to merge 2 sorted iterators of unique values. Example: 

```
it1 = [:a, :c, :d, :f]
it2 = [:b, :d, :e]
merged = mergesorted(it1, it2)
collect(merged)  # ==> [:a, :b, :c, :d, :e, :f]
```
(Note that `:d` presents in both iterators, but only single occurrence is emitted)