### PR TITLE
Change edge-case of iteration over size k subsets.

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -632,7 +632,7 @@ length(it::Binomial) = binomial(it.n,it.k)
 
 subsets(xs,k) = Binomial(xs,length(xs),k)
 
-start(it::Binomial) = (collect(Int64, 1:it.k), false)
+start(it::Binomial) = (collect(Int64, 1:it.k), it.k>it.n ? true : false)
 
 function next(it::Binomial, state::(@compat Tuple{Array{Int64,1}, Bool}))
     idx = state[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,11 +209,12 @@ test_groupby(
 @test collect(subsets([:a, :b, :c],1)) == Any[Symbol[:a], Symbol[:b], Symbol[:c]]
 @test collect(subsets([:a, :b, :c],2)) == Any[Symbol[:a,:b], Symbol[:a,:c], Symbol[:b,:c]]
 @test collect(subsets([:a, :b, :c],3)) == Any[Symbol[:a,:b,:c]]
+@test collect(subsets([:a, :b, :c],4)) == Any[]
 @test length(collect(subsets(collect(1:4),1))) == binomial(4,1)
 @test length(collect(subsets(collect(1:4),2))) == binomial(4,2)
 @test length(collect(subsets(collect(1:4),3))) == binomial(4,3)
 @test length(collect(subsets(collect(1:4),4))) == binomial(4,4)
-
+@test length(collect(subsets(collect(1:4),5))) == binomial(4,5)
 
 # Every nth
 # ---------


### PR DESCRIPTION
Instead of throwing an index error, return zero length vector when iterating over subsets of size k greater than base set size n.