### PR TITLE
Check empty case in `length(p::Product)`

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -311,16 +311,13 @@ if VERSION >= v"0.4-dev"
 else
     eltype(p::Product) = tuple(map(eltype, p.xss)...)
 end
-length(p::Product) = isempty(p.xss) ? 1 : prod(map(length, p.xss))
+length(p::Product) = mapreduce(length, *, 1, p.xss)
 
 product(xss...) = Product(xss...)
 
 function start(it::Product)
     n = length(it.xss)
     js = Any[start(xs) for xs in it.xss]
-    if n == 0
-        return js, nothing
-    end
     for i = 1:n
         if done(it.xss[i], js[i])
             return js, nothing
@@ -342,16 +339,13 @@ function next(it::Product, state)
     for i in 1:n
         if !done(it.xss[i], js[i])
             vs[i], js[i] = next(it.xss[i], js[i])
-            break
-        elseif i == n
-            vs = nothing
-            break
+            return ans, (js, vs)
         end
 
         js[i] = start(it.xss[i])
         vs[i], js[i] = next(it.xss[i], js[i])
     end
-    return ans, (js, vs)
+    ans, (js, nothing)
 end
 
 done(it::Product, state) = state[2] === nothing

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -311,7 +311,7 @@ if VERSION >= v"0.4-dev"
 else
     eltype(p::Product) = tuple(map(eltype, p.xss)...)
 end
-length(p::Product) = prod(map(length, p.xss))
+length(p::Product) = isempty(p.xss) ? 1 : prod(map(length, p.xss))
 
 product(xss...) = Product(xss...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,9 @@ x1 = 1:2:10
 x2 = 1:5
 @test collect(product(x1, x2)) == vec([(y1, y2) for y1 in x1, y2 in x2])
 
+@test length(product()) == 1
+@test collect(product()) == [()]
+
 # distinct
 # --------
 


### PR DESCRIPTION
`map(length, p.xss)` returns a `Vector{Any}`, which is problematic for `prod`. To fix this, special-case the length of the empty case.

Discovered on Gitter.