### PR TITLE
RFC: implemented `nth` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ Install this package with `Pkg.add("Iterators")`
     i = 4
     i = 3
     ```
+- **nth**(xs, n)
+    
+    Return the n'th element of `xs`. Mostly useful for non indexable collections.
+
+    Example:
+    ```julia
+    nth(1:3, 3)
+    ```
+
+    ```
+    3
+    ```
 
 - **takenth**(xs, n)
     

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -16,6 +16,7 @@ export
     imap,
     subsets,
     iterate,
+    nth,
     takenth,
     @itr
 
@@ -649,6 +650,26 @@ function next(it::Binomial, state::(@compat Tuple{Array{Int64,1}, Bool}))
 end
 
 done(it::Binomial, state::(@compat Tuple{Array{Int64,1}, Bool})) = state[2]
+
+
+# nth : return the nth element in a collection
+
+function nth(xs, n::Integer)
+    n > 0 || throw(BoundsError(xs, n))
+    # catch, if possible
+    applicable(length, xs) && (n ≤ length(xs) || throw(BoundsError(xs, n)))
+    s = start(xs)
+    i = 0
+    while !done(xs, s)
+        (val, s) = next(xs, s)
+        i += 1
+        i == n && return val
+    end
+    # catch iterators with no length but actual finite size less then n
+    throw(BoundsError(xs, n))    
+end     
+
+nth(xs::AbstractArray, n::Integer) = xs[n]
 
 
 # takenth(xs,n): take every n'th element from xs

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -654,6 +654,10 @@ done(it::Binomial, state::(@compat Tuple{Array{Int64,1}, Bool})) = state[2]
 
 # nth : return the nth element in a collection
 
+if VERSION < v"0.4"
+    Core.BoundsError(xs, n) = Core.BoundsError()
+end
+
 function nth(xs, n::Integer)
     n > 0 || throw(BoundsError(xs, n))
     # catch, if possible

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,6 +218,24 @@ test_groupby(
 @test length(collect(subsets(collect(1:4),4))) == binomial(4,4)
 
 
+# nth element
+# -----------
+for xs in Any[[1, 2, 3], 1:3, reshape(1:3, 3, 1)]
+    @test nth(xs, 3) == 3
+    @test_throws BoundsError nth(xs, 0)
+    @test_throws BoundsError nth(xs, 4)
+end 
+
+for xs in Any[take(1:3, 3), drop(-1:3, 2)]
+    @test nth(xs, 3) == 3
+    @test_throws BoundsError nth(xs, 0)
+end 
+
+s = subsets([1, 2, 3])
+@test_throws BoundsError nth(s, 0)
+@test_throws BoundsError nth(s, length(s) + 1)
+
+
 # Every nth
 # ---------
 


### PR DESCRIPTION
Hi, 

I find myself needing to get the nth element of a custom non indexable collection. This PR solves scratches my itch, but it might be useful to others. 

For `AbstractArrays` it falls back to standard `getindex` but for generic collections it just loops over the iterator as much as needed.