### PR TITLE
add a trivial outer constructor for Binomial

### DIFF
--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -466,6 +466,8 @@ immutable Binomial{T}
     n::Int64
     k::Int64
 end
+Binomial{T}(xs::AbstractVector{T}, n::Integer, k::Integer) = Binomial{T}(xs, n, k)
+
 iteratorsize{T<:Binomial}(::Type{T}) = HasLength()
 
 eltype{T}(::Type{Binomial{T}}) = Vector{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -386,6 +386,15 @@ sk9 = subsets(collect(1:4), 5)
 @test eltype(eltype(sk9)) == Int
 @test length(collect(sk9)) == binomial(4,5)
 
+# Implicit conversions
+sk10 = subsets(1:4, 3)
+@test eltype(eltype(sk10)) == Int
+@test length(collect(sk10)) == binomial(4, 3)
+
+sk11 = subsets(1:3, Int32(2))
+@test eltype(eltype(sk11)) == Int
+@test length(collect(sk11)) == binomial(3, 2)
+
 
 # nth element
 # -----------


### PR DESCRIPTION
Before, Binomial could only be called with arguments of type
(Vector{T}, Int64, Int64). Now it can be called with
(AbstractVector{T}, Integer, Integer), with the appropriate conversions
being done automatically when constructing the concrete type.

This fixes #93 and also makes it possible to call:

```
subsets(1:3, 2)
```

instead of

```
subsets(collect(1:3), 2)
```