### PR TITLE
[ci skip] Deprecate Iterators.jl in favour of IterTools.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 
 Common functional iterator patterns.
 
+## DEPRECATION
+
+Iterators.jl has been deprecated in favour of [IterTools.jl](https://github.com/JuliaCollections/IterTools.jl).
+Please update your package dependencies: Iterators 0.3.1 maps to IterTools 0.1.0.
+
+See [#104](https://github.com/JuliaCollections/Iterators.jl/issues/104) for more information.
+
 ## Installation
 
 Install this package with `Pkg.add("Iterators")`
@@ -98,7 +105,7 @@ Install this package with `Pkg.add("Iterators")`
     i = 3
     ```
 - **nth**(xs, n)
-    
+
     Return the n'th element of `xs`. Mostly useful for non indexable collections.
 
     Example:
@@ -111,7 +118,7 @@ Install this package with `Pkg.add("Iterators")`
     ```
 
 - **takenth**(xs, n)
-    
+
     Iterate through every n'th element of `xs`
 
     Example:

--- a/src/Iterators.jl
+++ b/src/Iterators.jl
@@ -2,6 +2,10 @@ __precompile__()
 
 module Iterators
 
+function __init__()
+    warn("Iterators.jl is deprecated; use IterTools.jl instead")
+end
+
 # gets around deprecation warnings in v0.6
 if isdefined(Base, :Iterators)
     import Base.Iterators: drop, countfrom, cycle, take, repeated
@@ -163,7 +167,7 @@ end
 
 """
     chain(xs...)
-    
+
 Iterate through any number of iterators in sequence.
 
 ```jldoctest


### PR DESCRIPTION
Last step of + closes #104 